### PR TITLE
feat(build-logic): implement Android convention plugins and CI publish

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -1,0 +1,23 @@
+# .github/workflows/publish-snapshot.yml
+name: Publish Convention Snapshot
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Publish build-logic to GitHub Packages
+        env:
+          GPR_USER: ${{ github.actor }}
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :build-logic:publish -Pgpr.user=$GPR_USER -Pgpr.key=$GPR_TOKEN --no-daemon

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.karthik.pro.engr.android.application)
 }
 
 android {
@@ -40,23 +41,5 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    implementation(libs.androidx.lifecycle.viewmodel.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.all.variants.preview)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,85 @@
+plugins {
+    `kotlin-dsl`
+    `java-gradle-plugin`
+    `maven-publish`
+    alias(libs.plugins.kotlin.jvm)
+}
+group = "karthik.pro.engr"
+version = "0.8.0"
+
+repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+
+dependencies {
+    // Gradle API
+    compileOnly(gradleApi())
+
+    // AGP for compile-time types (compileOnly so AGP is not bundled)
+    compileOnly(libs.gradle)                      // your libs alias for com.android.tools.build:gradle
+
+    // Kotlin Gradle plugin types (compileOnly)
+    compileOnly(libs.kotlin.gradle.plugin)        // your libs alias for org.jetbrains.kotlin:kotlin-gradle-plugin
+
+    // TestKit and test runtime
+    testImplementation(gradleTestKit())                                  // Gradle TestKit
+    testImplementation(libs.junit.jupiter.api)       // JUnit API
+    testRuntimeOnly(libs.junit.jupiter.engine)      // JUnit engine to run tests
+    testImplementation(libs.assertj)
+    implementation(kotlin("test"))
+}
+
+gradlePlugin {
+    plugins {
+        create("androidApplicationPlugin") {
+            id = libs.plugins.karthik.pro.engr.android.application.get().pluginId
+            implementationClass = "com.karthik.pro.engr.AndroidApplicationConventionPlugin"
+        }
+        create("androidLibraryPlugin") {
+            id = libs.plugins.karthik.pro.engr.android.library.get().pluginId
+            implementationClass = "com.karthik.pro.engr.AndroidLibraryConventionPlugin"
+        }
+    }
+}
+
+publishing {
+    // minimal explicit publication for the plugin implementation jar
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            groupId = "karthik.pro.engr"
+            artifactId = "convention-plugins"
+            version = project.version.toString()
+        }
+    }
+
+    publications.withType<MavenPublication>().configureEach {
+        groupId = "karthik.pro.engr"
+        artifactId = when (name) {
+            "pluginMaven" -> "android.application.gradle.plugin"
+            "androidApplicationPluginPluginMarkerMaven" -> "android-application-plugin-marker"
+            "androidLibraryPluginPluginMarkerMaven" -> "android-library-plugin-marker"
+            "mavenJava" -> "convention-plugins"
+            else -> name.replace("Publication", "").lowercase().replace("[^a-z0-9.-]".toRegex(), "-")
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/karthik-pro-engr/architecting-state")
+            credentials {
+                username = findProperty("gpr.user") as String? ?: System.getenv("GPR_USER")
+                password = findProperty("gpr.token") as String? ?: System.getenv("GPR_TOKEN")
+            }
+        }
+    }
+}
+
+// Use JUnit Platform for tests:
+tasks.test {
+    useJUnitPlatform()
+}

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -13,21 +13,20 @@ repositories {
     gradlePluginPortal()
 }
 
-
 dependencies {
     // Gradle API
     compileOnly(gradleApi())
 
     // AGP for compile-time types (compileOnly so AGP is not bundled)
-    compileOnly(libs.gradle)                      // your libs alias for com.android.tools.build:gradle
+    compileOnly(libs.gradle) // your libs alias for com.android.tools.build:gradle
 
     // Kotlin Gradle plugin types (compileOnly)
-    compileOnly(libs.kotlin.gradle.plugin)        // your libs alias for org.jetbrains.kotlin:kotlin-gradle-plugin
+    compileOnly(libs.kotlin.gradle.plugin) // your libs alias for org.jetbrains.kotlin:kotlin-gradle-plugin
 
     // TestKit and test runtime
-    testImplementation(gradleTestKit())                                  // Gradle TestKit
-    testImplementation(libs.junit.jupiter.api)       // JUnit API
-    testRuntimeOnly(libs.junit.jupiter.engine)      // JUnit engine to run tests
+    testImplementation(gradleTestKit()) // Gradle TestKit
+    testImplementation(libs.junit.jupiter.api) // JUnit API
+    testRuntimeOnly(libs.junit.jupiter.engine) // JUnit engine to run tests
     testImplementation(libs.assertj)
     implementation(kotlin("test"))
 }

--- a/build-logic/convention/src/main/kotlin/com/karthik/pro/engr/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/karthik/pro/engr/AndroidApplicationConventionPlugin.kt
@@ -66,7 +66,6 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             libs.findLibrary("androidx-lifecycle-viewmodel-ktx").ifPresent { add("implementation", it.get()) }
             libs.findLibrary("androidx-lifecycle-viewmodel-compose").ifPresent { add("implementation", it.get()) }
 
-
             // AppCompat + Material (safe defaults)
             libs.findLibrary("androidx-appcompat").ifPresent { add("implementation", it.get()) }
             libs.findLibrary("material").ifPresent { add("implementation", it.get()) }

--- a/build-logic/convention/src/main/kotlin/com/karthik/pro/engr/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/karthik/pro/engr/AndroidApplicationConventionPlugin.kt
@@ -1,0 +1,85 @@
+// build-logic/convention/src/main/kotlin/com/karthik/pro/engr/buildlogic/AndroidApplicationConventionPlugin.kt
+package com.karthik.pro.engr
+
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        // apply AGP & Kotlin Android plugin to consumer module
+        project.pluginManager.apply("com.android.application")
+        project.pluginManager.apply("org.jetbrains.kotlin.android")
+
+        // Configure android { } via the typed DSL (modern API)
+        project.extensions.configure<ApplicationExtension>("android") {
+            compileSdk = 36
+
+            defaultConfig {
+                minSdk = 21
+                targetSdk = 36
+                testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+            }
+
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+
+            // Optional: common build types / proguard, flavors etc. can be added here
+        }
+
+        // Resolve libs from version catalog available to included build
+        val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+        // Add conservative, commonly-used dependencies into the consumer module
+        project.dependencies.apply {
+            // core + lifecycle
+            add("implementation", libs.findLibrary("androidx-core-ktx").get())
+            add("implementation", libs.findLibrary("androidx-lifecycle-runtime-ktx").get())
+
+            // Activity Compose (implementation-only)
+            libs.findLibrary("androidx-activity-compose").ifPresent {
+                add("implementation", it.get())
+            }
+
+            // Compose BOM (apply as platform) if present
+            libs.findLibrary("androidx-compose-bom").ifPresent { bom ->
+                val platformDep = project.dependencies.platform(bom.get())
+                add("implementation", platformDep)
+                // Also add platform to androidTestImplementation so test compose libs resolve versions
+                add("androidTestImplementation", platformDep)
+                // Optionally add to testImplementation if you have JVM compose tests
+                add("testImplementation", platformDep)
+            }
+
+            // Compose UI libs (implementation)
+            libs.findLibrary("androidx-ui").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-ui-graphics").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-ui-tooling-preview").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-material3").ifPresent { add("implementation", it.get()) }
+
+            // ViewModel helpers
+            libs.findLibrary("androidx-lifecycle-viewmodel-ktx").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-lifecycle-viewmodel-compose").ifPresent { add("implementation", it.get()) }
+
+
+            // AppCompat + Material (safe defaults)
+            libs.findLibrary("androidx-appcompat").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("material").ifPresent { add("implementation", it.get()) }
+
+            // Test deps
+            libs.findLibrary("junit").ifPresent { add("testImplementation", it.get()) }
+            libs.findLibrary("androidx-junit").ifPresent { add("androidTestImplementation", it.get()) }
+            libs.findLibrary("androidx-espresso-core").ifPresent { add("androidTestImplementation", it.get()) }
+
+            // Compose test helpers
+            libs.findLibrary("androidx-ui-test-junit4").ifPresent { add("androidTestImplementation", it.get()) }
+            libs.findLibrary("androidx-ui-test-manifest").ifPresent { add("debugImplementation", it.get()) }
+            libs.findLibrary("androidx-ui-tooling").ifPresent { add("debugImplementation", it.get()) }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/karthik/pro/engr/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/karthik/pro/engr/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,59 @@
+// build-logic/convention/src/main/kotlin/com/karthik/pro/engr/buildlogic/AndroidLibraryConventionPlugin.kt
+package com.karthik.pro.engr
+
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.pluginManager.apply("com.android.library")
+        project.pluginManager.apply("org.jetbrains.kotlin.android")
+
+        project.extensions.configure<LibraryExtension>("android") {
+            compileSdk = 36
+
+            defaultConfig {
+                minSdk = 21
+                targetSdk = 36
+            }
+
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+        }
+
+        val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs")
+        project.dependencies.apply {
+            // conservative defaults for libraries
+            add("implementation", libs.findLibrary("androidx-core-ktx").get())
+            libs.findLibrary("androidx-lifecycle-runtime-ktx").ifPresent { add("implementation", it.get()) }
+
+            // Expose material/appcompat only if library needs them (we prefer implementation here)
+            libs.findLibrary("androidx-appcompat").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("material").ifPresent { add("implementation", it.get()) }
+
+            // Compose support for libraries that are UI modules (optional)
+            libs.findLibrary("androidx-activity-compose").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-compose-bom").ifPresent { bom ->
+                val platformDep = project.dependencies.platform(bom.get())
+                add("implementation", platformDep)
+                // Also add platform to androidTestImplementation so test compose libs resolve versions
+                add("androidTestImplementation", platformDep)
+                // Optionally add to testImplementation if you have JVM compose tests
+                add("testImplementation", platformDep)
+            }
+            libs.findLibrary("androidx-ui").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-ui-graphics").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-ui-tooling-preview").ifPresent { add("implementation", it.get()) }
+            libs.findLibrary("androidx-material3").ifPresent { add("implementation", it.get()) }
+
+            // Test deps
+            libs.findLibrary("junit").ifPresent { add("testImplementation", it.get()) }
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,17 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            // Root project's catalog file (make sure this path is correct)
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/callback/build.gradle.kts
+++ b/callback/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.karthik.pro.engr.android.application)
 }
 
 android {
@@ -40,23 +41,6 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
     implementation(libs.all.variants.preview)
     implementation(project(":statelib"))
-
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,14 @@
 [versions]
 agp = "8.11.2"
+gradle = "8.11.2"
+junitJupiterApi = "6.0.0"
+junitJupiterEngine = "6.0.0"
 kotlin = "2.2.20"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
+kotlinGradlePlugin = "1.9.20"
 lifecycleRuntimeKtx = "2.9.4"
 activityCompose = "1.11.0"
 composeBom = "2024.09.00"
@@ -12,9 +16,12 @@ androidxLifecycle = "2.9.3"
 allVariantsPreview = "0.3.0-rc1"
 appcompat = "1.7.1"
 material = "1.10.0"
+jupiter= "6.0.0"
+assertJ= "3.24.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -32,11 +39,23 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 all-variants-preview = { group = "io.github.karthik-pro-engr", name = "preview", version.ref = "allVariantsPreview" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiterApi" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiterEngine" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+
+# build-logic
+jupiter = {group= "org.junit.jupiter", name = "junit-jupiter", version.ref = "jupiter"}
+assertj = {group= "org.assertj", name = "assertj-core", version.ref = "assertJ"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 
+
+# Plugins defined by this projec
+karthik-pro-engr-android-application = { id = "karthik.pro.engr.android.application" }
+karthik-pro-engr-android-library = { id = "karthik.pro.engr.android.library" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google {
             content {

--- a/statelib/build.gradle.kts
+++ b/statelib/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.karthik.pro.engr.android.library)
     id("kotlin-parcelize")
 }
 
@@ -31,14 +32,4 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
-}
-
-dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/viewmodel-ssh/build.gradle.kts
+++ b/viewmodel-ssh/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.karthik.pro.engr.android.application)
-
 }
 
 android {

--- a/viewmodel-ssh/build.gradle.kts
+++ b/viewmodel-ssh/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.karthik.pro.engr.android.application)
+
 }
 
 android {
@@ -40,24 +42,6 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    implementation(libs.androidx.lifecycle.viewmodel.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.all.variants.preview)
     implementation(project(":statelib"))
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/viewmodel-ssh/src/main/java/com/karthik/pro/engr/viewmodelssh/ui/screens/BalancedEnergyScreen.kt
+++ b/viewmodel-ssh/src/main/java/com/karthik/pro/engr/viewmodelssh/ui/screens/BalancedEnergyScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -148,6 +146,5 @@ fun InputTextField(
 @AllVariantsPreview
 @Composable
 private fun BalancedEnergyScreenPreview() {
-    BalancedEnergyScreen(
-    )
+    BalancedEnergyScreen()
 }


### PR DESCRIPTION
- Implement AndroidApplicationConventionPlugin and AndroidLibraryConventionPlugin
  under build-logic to centrally apply AGP, Kotlin Android, and a conservative
  set of common dependencies (implementation-scoped; BOM applied to test scopes).
- Modules can opt in via the plugin alias: alias(libs.plugins.karthik.pro.engr.android.application)
- Add CI workflow (publish-plugin.yml) to publish the convention plugin to the
  configured Maven registry on main/tag releases.
- Tested locally: built and assembled consumer modules with the convention
  plugin applied; validated dependency resolution for androidTest configs.

Why: centralizes dependency and Android module configuration while keeping
per-module compile classpath small and consistent across the codebase.