### PR TITLE
feat(statelib): accept 'p'/'c' shorthand for producer/consumer inputs

### DIFF
--- a/app/src/main/java/com/karthik/pro/engr/architectingstate/ui/viewmodel/BalancedEnergyViewmodel.kt
+++ b/app/src/main/java/com/karthik/pro/engr/architectingstate/ui/viewmodel/BalancedEnergyViewmodel.kt
@@ -25,8 +25,8 @@ class BalancedEnergyViewmodel : ViewModel() {
         val trimmed = type.trim()
         when {
             trimmed.isEmpty() -> errorMessage = "Input cannot be empty"
-            trimmed.lowercase() !in listOf("producer", "consumer") -> errorMessage =
-                "Input must be either 'producer' or 'consumer'"
+            trimmed.lowercase() !in listOf("p", "c") -> errorMessage =
+                "Input must be either 'p' or 'c'"
 
             else -> {
                 _houseTypes.add(type)

--- a/callback/src/main/java/com/karthik/pro/engr/callback/MainActivity.kt
+++ b/callback/src/main/java/com/karthik/pro/engr/callback/MainActivity.kt
@@ -67,8 +67,8 @@ class MainActivity : ComponentActivity(), EnergyListener {
         val trimmed = type.trim()
         when {
             trimmed.isEmpty() -> errorMessage = "Input cannot be empty"
-            trimmed.lowercase() !in listOf("producer", "consumer") -> errorMessage =
-                "Input must be either 'producer' or 'consumer'"
+            trimmed.lowercase() !in listOf("p", "c") -> errorMessage =
+                "Input must be either 'p' or 'c'"
 
             else -> {
                 houseTypes.add(type)

--- a/stateflow/src/main/java/com/karthik/pro/engr/stateflow/ui/viewmodel/BalancedEnergyViewModelStateFlow.kt
+++ b/stateflow/src/main/java/com/karthik/pro/engr/stateflow/ui/viewmodel/BalancedEnergyViewModelStateFlow.kt
@@ -23,10 +23,10 @@ class BalancedEnergyViewModelStateFlow() : ViewModel() {
                         val error = when {
                             trimmed.isEmpty() -> "Input cannot be empty"
                             trimmed.lowercase() !in listOf(
-                                "producer",
-                                "consumer"
+                                "p",
+                                "c"
                             ) ->
-                                "Input must be either 'producer' or 'consumer'"
+                                "Input must be either 'p' or 'c'"
 
                             else -> {
                                 ""

--- a/statelib/src/main/java/com/karthik/pro/engr/lib/domain/energy/EnergyAnalyzer.kt
+++ b/statelib/src/main/java/com/karthik/pro/engr/lib/domain/energy/EnergyAnalyzer.kt
@@ -12,9 +12,9 @@ object EnergyAnalyzer {
         var maxLen = 0
         houseTypes.forEachIndexed { index, element ->
             prefixSum += when (element.lowercase()) {
-                "producer" -> 1
+                "p" -> 1
 
-                "consumer" -> -1
+                "c" -> -1
 
                 else -> 0
             }

--- a/statelib/src/main/res/values/strings.xml
+++ b/statelib/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="placeholder_input">Producer or Consumer</string>
+    <string name="placeholder_input">P or C</string>
     <string name="label_house_type">Enter House Type</string>
     <string name="button_add_house_type">Add House type</string>
     <string name="text_no_house_types_added">No House Types Added</string>

--- a/viewmodel-livedata/src/main/java/com/karthik/pro/engr/viewmodel/livedata/ui/viewmodel/BalancedEnergyViewModelLive.kt
+++ b/viewmodel-livedata/src/main/java/com/karthik/pro/engr/viewmodel/livedata/ui/viewmodel/BalancedEnergyViewModelLive.kt
@@ -26,8 +26,8 @@ class BalancedEnergyViewModelLive(private val ss: SavedStateHandle) : ViewModel(
         val trimmed = type.trim()
         when {
             trimmed.isEmpty() -> errorMessage = "Input cannot be empty"
-            trimmed.lowercase() !in listOf("producer", "consumer") -> errorMessage =
-                "Input must be either 'producer' or 'consumer'"
+            trimmed.lowercase() !in listOf("p", "c") -> errorMessage =
+                "Input must be either 'p' or 'c'"
 
             else -> {
                 houseTypes = houseTypes.orEmpty().plus(trimmed)

--- a/viewmodel-ssh/src/main/java/com/karthik/pro/engr/viewmodelssh/ui/viewmodel/BalancedEnergyViewModel.kt
+++ b/viewmodel-ssh/src/main/java/com/karthik/pro/engr/viewmodelssh/ui/viewmodel/BalancedEnergyViewModel.kt
@@ -37,8 +37,8 @@ class BalancedEnergyViewModel(private val ss: SavedStateHandle) : ViewModel() {
         val trimmed = type.trim()
         when {
             trimmed.isEmpty() -> errorMessage = "Input cannot be empty"
-            trimmed.lowercase() !in listOf("producer", "consumer") -> errorMessage =
-                "Input must be either 'producer' or 'consumer'"
+            trimmed.lowercase() !in listOf("p", "c") -> errorMessage =
+                "Input must be either 'p' or 'c'"
 
             else -> {
                 houseTypes.add(trimmed)


### PR DESCRIPTION
- Update parsing logic to map case-insensitive "p" -> +1 and "c" -> -1 (replaces previous "producer"/"consumer" string matches).
- Update string resource `placeholder_input` from "Producer or Consumer" to "P or C".
- Update input validation and error message to require "p" or "c": "Input must be either 'p' or 'c'".
- Adjusted UI/validation messages to match the shorthand and keep UX concise.